### PR TITLE
BerChain Twitter name correction

### DIFF
--- a/data/24/events/berchain/index.toml
+++ b/data/24/events/berchain/index.toml
@@ -103,4 +103,4 @@ status = "available"
 # web = "https://www.eventbrite.co.uk/e/blockchain-meets-ai-berchains-5th-anniversary-tickets-880861940777?aff=BBW2024"
 
 # twitter account
-twitter = "https://twitter.com/Berchain"
+twitter = "https://twitter.com/ber_chain"


### PR DESCRIPTION
The correct ID https://twitter.com/ber_chain